### PR TITLE
Handle time-range properly (fix date format)

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -219,10 +219,7 @@ export const fetchCalendarObjects = async (params: {
     (
       await calendarQuery({
         url: calendar.url,
-        props: [
-          { name: 'getetag', namespace: DAVNamespace.DAV },
-          { name: 'calendar-data', namespace: DAVNamespace.DAV },
-        ],
+        props: [{ name: 'getetag', namespace: DAVNamespace.DAV }],
         filters,
         depth: '1',
         headers,

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -202,8 +202,8 @@ export const fetchCalendarObjects = async (params: {
                 {
                   type: 'time-range',
                   attributes: {
-                    start: `${timeRange?.start.slice(0, -5)}Z`,
-                    end: `${timeRange?.end.slice(0, -5)}Z`,
+                    start: timeRange?.start.replace(/[-:Z]/g, ''),
+                    end: timeRange?.end.replace(/[-:Z]/g, ''),
                   },
                 },
               ]
@@ -219,7 +219,10 @@ export const fetchCalendarObjects = async (params: {
     (
       await calendarQuery({
         url: calendar.url,
-        props: [{ name: 'getetag', namespace: DAVNamespace.DAV }],
+        props: [
+          { name: 'getetag', namespace: DAVNamespace.DAV },
+          { name: 'calendar-data', namespace: DAVNamespace.DAV },
+        ],
         filters,
         depth: '1',
         headers,


### PR DESCRIPTION
The previous approach trimmed the date strings given in time-range
filter, so for `2021-08-15T00:00:00Z` the lib sent `2021-08-15T00:0`,
which didn't make much sense for the server. It's now changed to
return `20210815T000000`, which is understood by the server