### PR TITLE
Send the time-range dates in format conforming to the standard

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -202,8 +202,8 @@ export const fetchCalendarObjects = async (params: {
                 {
                   type: 'time-range',
                   attributes: {
-                    start: `${timeRange?.start.slice(0, 19)}Z`,
-                    end: `${timeRange?.end.slice(0, 19)}Z`,
+                    start: timeRange?.start.replace(/[-:.]/g, ''),
+                    end: timeRange?.end.replace(/[-:.]/g, ''),
                   },
                 },
               ]


### PR DESCRIPTION
Dates in time-range [have to](https://icalendar.org/CalDAV-Access-RFC-4791/9-9-caldav-time-range-xml-element.html) be sent in the caldav's [DATE-TIME format](https://icalendar.org/iCalendar-RFC-5545/3-3-5-date-time.html),
so it should be `20210817T120000` and not `2021-08-17T12:00.00Z`.

I've tested v1.0.5 with Nextcloud and filtering by time-range doesn't work. Changes in this PR make it work.

Ref calendso/calendso#479