### PR TITLE
🐛 Ensure service discovery redirect maintains the proper port

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -35,6 +35,11 @@ export const serviceDiscovery = async (params: {
       if (typeof location === 'string' && location.length) {
         debug(`Service discovery redirected to ${location}`);
         const serviceURL = new URL(location, endpoint);
+
+        if (serviceURL.hostname === uri.hostname && uri.port && !serviceURL.port) {
+          serviceURL.port = uri.port;
+        }
+
         serviceURL.protocol = endpoint.protocol ?? 'http';
         return serviceURL.href;
       }


### PR DESCRIPTION
In cases where the caldav server's endpoint is not on the default port (80 or 443), requests fail service discovery because the `302` response `Location` header excludes the original request's port. This fixes that mismatch in those scenarios.